### PR TITLE
Fix Package-Requires

### DIFF
--- a/realtime-preview.el
+++ b/realtime-preview.el
@@ -1,9 +1,33 @@
 ;;; realtime-preview.el --- Realtime preview by eww -*- lexical-binding: t; -*-
 
+;; Copyright (c) 2014 niku
+
 ;; Author: niku <niku@niku.name>
 ;; URL: https://github.com/niku/realtime-preview
 ;; Version 0.0.1
 ;; Package-Requires: ((emacs "24.4"))
+
+
+;; This file is not part of GNU Emacs.
+
+;; The MIT License (MIT)
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy of
+;; this software and associated documentation files (the "Software"), to deal in
+;; the Software without restriction, including without limitation the rights to
+;; use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+;; the Software, and to permit persons to whom the Software is furnished to do so,
+;; subject to the following conditions:
+;;
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+;;
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+;; FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+;; COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+;; IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ;;; Commentary:
 

--- a/realtime-preview.el
+++ b/realtime-preview.el
@@ -3,7 +3,7 @@
 ;; Author: niku <niku@niku.name>
 ;; URL: https://github.com/niku/realtime-preview
 ;; Version 0.0.1
-;; Package-Requires: (emacs "24.4")
+;; Package-Requires: ((emacs "24.4"))
 
 ;;; Commentary:
 

--- a/realtime-preview.el
+++ b/realtime-preview.el
@@ -51,6 +51,7 @@ while doc = gets(\"\\0\")
 end
 " output-file-name))
 
+;;;### autoload
 (defun realtime-preview ()
   "Start realtime preview."
   (interactive)


### PR DESCRIPTION
(#10 がなぜかcloseされてしまった)

* Caskでインストールに失敗するのでPackage-Requiresヘッダを修正
* ヘッダにCopyright
* autoload cookieを記述
  * [GNU Emacs Lisp Reference Manual: Autoload](http://www.gnu.org/software/emacs/manual/html_node/elisp/Autoload.html)
